### PR TITLE
Added OpenAPI 3.0 / Swagger generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,26 +27,44 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
     </repositories>
 
     <dependencies>
+        <!-- Minecraft plugin -->
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
+        <!-- HTTP Server -->
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
             <version>3.7.0</version>
         </dependency>
-
+        <!-- Generating Swagger YML -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.34</version>
+        </dependency>
+        <!-- Generating Swagger UI -->
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>swagger-ui</artifactId>
+            <version>3.24.3</version>
+        </dependency>
         <!-- for json serialization -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -58,7 +76,6 @@
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/servertap/api/v1/EconomyApi.java
+++ b/src/main/java/io/servertap/api/v1/EconomyApi.java
@@ -2,6 +2,7 @@ package io.servertap.api.v1;
 
 import java.util.UUID;
 
+import io.javalin.plugin.openapi.annotations.*;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
@@ -18,10 +19,40 @@ public class EconomyApi {
         PAY, DEBIT
     }
 
+    @OpenApi(
+        path = "/v1/economy/pay",
+        method = HttpMethod.POST,
+        summary = "Pay a player",
+        description = "Deposits the provided amount into the player's Vault",
+        tags = {"Economy"},
+        formParams = {
+            @OpenApiFormParam(name = "uuid"),
+            @OpenApiFormParam(name = "amount", type = Double.class)
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
+            @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
+        }
+    )
     public static void playerPay(Context ctx) {
         accountManager(ctx, TransactionType.PAY);
     }
 
+    @OpenApi(
+        path = "/v1/economy/debit",
+        method = HttpMethod.POST,
+        summary = "Debit a player",
+        description = "Withdraws the provided amount out of the player's Vault",
+        tags = {"Economy"},
+        formParams = {
+            @OpenApiFormParam(name = "uuid"),
+            @OpenApiFormParam(name = "amount", type = Double.class)
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
+            @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
+        }
+    )
     public static void playerDebit(Context ctx) {
         accountManager(ctx, TransactionType.DEBIT);
     }

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -1,6 +1,7 @@
 package io.servertap.api.v1;
 
 import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.*;
 import io.servertap.PluginEntrypoint;
 import io.servertap.api.v1.models.Player;
 
@@ -11,6 +12,14 @@ import java.util.ArrayList;
 
 public class PlayerApi {
 
+    @OpenApi(
+        path = "/v1/players",
+        summary = "Gets all currently online players",
+        tags = {"Player"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = Player.class, isArray = true))
+        }
+    )
     public static void playersGet(Context ctx) {
         ArrayList<Player> players = new ArrayList<>();
 
@@ -39,6 +48,18 @@ public class PlayerApi {
         ctx.json(players);
     }
 
+    @OpenApi(
+        path = "/v1/players/:player",
+        method = HttpMethod.GET,
+        summary = "Gets a specific online player by their username",
+        tags = {"Player"},
+        pathParams = {
+            @OpenApiParam(name = "player", description = "Username of the player")
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = Player.class))
+        }
+    )
     public static void playerGet(Context ctx) {
         Player p = new Player();
 
@@ -64,6 +85,14 @@ public class PlayerApi {
         ctx.json(p);
     }
 
+    @OpenApi(
+        path = "/v1/allPlayers",
+        summary = "Gets all players that have ever joined the server ",
+        tags = {"Player"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = io.servertap.api.v1.models.OfflinePlayer.class, isArray = true))
+        }
+    )
     public static void offlinePlayersGet(Context ctx) {
 
         ArrayList<io.servertap.api.v1.models.OfflinePlayer> players = new ArrayList<>();

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -3,6 +3,7 @@ package io.servertap.api.v1;
 import com.google.gson.Gson;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
+import io.javalin.plugin.openapi.annotations.*;
 import io.servertap.api.v1.models.Server;
 import io.servertap.api.v1.models.ServerBan;
 import io.servertap.api.v1.models.ServerHealth;
@@ -29,10 +30,26 @@ public class ServerApi {
 
     private static final Logger log = Bukkit.getLogger();
 
+    @OpenApi(
+        path = "/v1/ping",
+        summary = "pong!",
+        tags = {"Server"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json"))
+        }
+    )
     public static void ping(Context ctx) {
         ctx.json("pong");
     }
 
+    @OpenApi(
+        path = "/v1/server",
+        summary = "Get information about the server",
+        tags = {"Server"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = Server.class))
+        }
+    )
     public static void serverGet(Context ctx) {
         Server server = new Server();
         org.bukkit.Server bukkitServer = Bukkit.getServer();
@@ -102,10 +119,31 @@ public class ServerApi {
         ctx.json(server);
     }
 
+    @OpenApi(
+        path = "/v1/broadcast",
+        method = HttpMethod.POST,
+        summary = "Send broadcast visible to those currently online.",
+        tags = {"Server"},
+        formParams = {
+            @OpenApiFormParam(name = "message", type = String.class)
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json"))
+        }
+    )
     public static void broadcastPost(Context ctx) {
         Bukkit.broadcastMessage(ctx.formParam("message"));
+        ctx.json("true");
     }
 
+    @OpenApi(
+        path = "/v1/worlds",
+        summary = "Get information about all worlds",
+        tags = {"Server"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class, isArray = true))
+        }
+    )
     public static void worldsGet(Context ctx) {
         List<World> worlds = new ArrayList<>();
         Bukkit.getServer().getWorlds().forEach(world -> worlds.add(fromBukkitWorld(world)));
@@ -113,6 +151,17 @@ public class ServerApi {
         ctx.json(worlds);
     }
 
+    @OpenApi(
+        path = "/v1/worlds/:world",
+        summary = "Get information about a specific world",
+        tags = {"Server"},
+        pathParams = {
+            @OpenApiParam(name = "world", description = "The name of the world")
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class))
+        }
+    )
     public static void worldGet(Context ctx) {
         org.bukkit.World bukkitWorld = Bukkit.getServer().getWorld(ctx.pathParam("world"));
 
@@ -180,6 +229,15 @@ public class ServerApi {
         return whitelist;
     }
 
+    @OpenApi(
+        path = "/v1/whitelist",
+        method = HttpMethod.GET,
+        summary = "Get the whitelist",
+        tags = {"Server"},
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(from = Whitelist.class, isArray = true))
+        }
+    )
     public static void whitelistGet(Context ctx){
         if(!Bukkit.getServer().hasWhitelist()){
             // TODO: Handle Errors better
@@ -189,6 +247,20 @@ public class ServerApi {
         ctx.json(getWhitelist());
     }
 
+    @OpenApi(
+        path = "/v1/whitelist",
+        method = HttpMethod.POST,
+        summary = "Update the whitelist",
+        description = "Possible responses are: `success`, `failed`, `Error: duplicate entry`, and `No whitelist`.",
+        tags = {"Server"},
+        formParams = {
+                @OpenApiFormParam(name = "uuid", type = String.class),
+                @OpenApiFormParam(name = "name", type = String.class)
+        },
+        responses = {
+            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json"))
+        }
+    )
     public static void whitelistPost(Context ctx){
         //TODO: handle the event that no uuid is passed by ctx
         final org.bukkit.Server bukkitServer = Bukkit.getServer();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: ServerTap
 main: io.servertap.PluginEntrypoint
-version: 1.0-SNAPSHOT
+version: 0.0.2-SNAPSHOT
+description: ServerTap is a REST API for Bukkit/Spigot/PaperMC Minecraft servers.
 api-version: 1.14
 softdepend:
   - Vault


### PR DESCRIPTION
CHANGELOG
- Removed explicit central Maven repository entry from pom.xml. It was originally included because I didn't know how to use IntelliJ correctly. 😅
- Automatically generate swagger doc at runtime: `/swagger-doc`
- Include swagger-ui viewable at runtime: `/swagger`
- To ensure that class reflection is possible by Swagger, `com.github.MilkBowl.VaultAPI` classes are now shaded into the jar file. This has (so far) presented no conflicts or issues when running.
- Documented all endpoints with `@OpenApi(...)` annotations. See documentation for future usage: https://javalin.io/plugins/openapi#annotations

A preview of the resulting swagger-ui is attached.
![Screenshot from 2020-05-17 00-42-57](https://user-images.githubusercontent.com/4109551/82136844-89918680-97d7-11ea-8316-84d2047e3a71.png)

