### PR TITLE
Feature inventory read

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             <id>central</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
+            <layout>default</layout>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -59,6 +64,12 @@
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- NBT API integration -->
+        <dependency>
+          <groupId>de.tr7zw</groupId>
+          <artifactId>item-nbt-api-plugin</artifactId>
+          <version>2.3.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -8,4 +8,9 @@ public class Constants {
     public static final String VAULT_MISSING = "Vault not found. Related functionality disabled";
     public static final String VAULT_MISSING_PAY_PARAMS = "Missing uuid and/or amount";
     public static final String VAULT_GREATER_THAN_ZERO = "You must use a value greater than zero";
+
+    //Player Related Messages
+    public static final String PLAYER_MISSING_PARAMS = "Missing uuid and/or world";
+    public static final String PLAYER_INV_PARSE_FAIL = "A problem occured when attempting to parse the user file";
+    public static final String PLAYER_NOT_FOUND = "Player cannot be found";
 }

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -66,7 +66,7 @@ public class PluginEntrypoint extends JavaPlugin {
                 get("players", PlayerApi::playersGet);
                 get("players/:player", PlayerApi::playerGet);
                 get("allPlayers", PlayerApi::offlinePlayersGet);
-                get("player/:uuid/:world/inventory", PlayerApi::getPlayerInv);
+                get("players/:uuid/:world/inventory", PlayerApi::getPlayerInv);
                 // Whitelist routes
                 get("whitelist", ServerApi::whitelistGet);
                 post("whitelist", ServerApi::whitelistPost);

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -66,7 +66,7 @@ public class PluginEntrypoint extends JavaPlugin {
                 get("players", PlayerApi::playersGet);
                 get("players/:player", PlayerApi::playerGet);
                 get("allPlayers", PlayerApi::offlinePlayersGet);
-
+                get("players/:uuid/:world/inventory", PlayerApi::getPlayerInv);
                 // Whitelist routes
                 get("whitelist", ServerApi::whitelistGet);
                 post("whitelist", ServerApi::whitelistPost);
@@ -74,6 +74,8 @@ public class PluginEntrypoint extends JavaPlugin {
                 // Economy routes
                 post("economy/pay", EconomyApi::playerPay);
                 post("economy/debit", EconomyApi::playerDebit);
+
+
             });
         });
 

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -66,7 +66,7 @@ public class PluginEntrypoint extends JavaPlugin {
                 get("players", PlayerApi::playersGet);
                 get("players/:player", PlayerApi::playerGet);
                 get("allPlayers", PlayerApi::offlinePlayersGet);
-                get("players/:uuid/:world/inventory", PlayerApi::getPlayerInv);
+                get("player/:uuid/:world/inventory", PlayerApi::getPlayerInv);
                 // Whitelist routes
                 get("whitelist", ServerApi::whitelistGet);
                 post("whitelist", ServerApi::whitelistPost);

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -2,6 +2,7 @@ package io.servertap.api.v1;
 
 import io.javalin.http.Context;
 import io.javalin.http.InternalServerErrorResponse;
+import io.servertap.Constants;
 import io.servertap.PluginEntrypoint;
 import io.servertap.api.v1.models.ItemStack;
 import io.servertap.api.v1.models.Player;
@@ -103,12 +104,12 @@ public class PlayerApi {
     }
 
     public static void getPlayerInv(Context ctx) {
-        if (ctx.formParam("uuid") == null || ctx.formParam("world") == null) {
+        if (ctx.pathParam("uuid") == null || ctx.pathParam("world") == null) {
             // TODO: Move to Constants
-            throw new InternalServerErrorResponse("Missing uuid and/or world");
+            throw new InternalServerErrorResponse(Constants.PLAYER_MISSING_PARAMS);
         }
         ArrayList<ItemStack> inv = new ArrayList<ItemStack>();
-        org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.formParam("uuid")));
+        org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.pathParam("uuid")));
         if (player != null) {
             Integer location = -1;
             for (org.bukkit.inventory.ItemStack itemStack : player.getInventory().getContents()) {
@@ -128,7 +129,7 @@ public class PlayerApi {
                 String playerDatPath = Paths.get(new File("./").getAbsolutePath(), ctx.formParam("world"), "playerdata", ctx.formParam("uuid") + ".dat").toString();
                 File playerfile = new File(playerDatPath);
                 if(!playerfile.exists()){
-                    throw new InternalServerErrorResponse("Player file cannot be found");
+                    throw new InternalServerErrorResponse(Constants.PLAYER_NOT_FOUND);
                 }
                 NBTFile playerFile = new NBTFile(playerfile);
 
@@ -143,7 +144,7 @@ public class PlayerApi {
                 ctx.json(inv);
             } catch (Exception e) {
                 Bukkit.getLogger().warning(e.getMessage());
-                throw new InternalServerErrorResponse("A problem occured when attempting to parse the user file");
+                throw new InternalServerErrorResponse(Constants.PLAYER_INV_PARSE_FAIL);
             }
         }
 

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -9,6 +9,7 @@ import io.servertap.api.v1.models.Player;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.InventoryHolder;
 
 import de.tr7zw.nbtapi.NBTEntity;
 import de.tr7zw.nbtapi.NBTFile;
@@ -111,6 +112,7 @@ public class PlayerApi {
         ArrayList<ItemStack> inv = new ArrayList<ItemStack>();
         org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.pathParam("uuid")));
         if (player != null) {
+            player.updateInventory();
             Integer location = -1;
             for (org.bukkit.inventory.ItemStack itemStack : player.getInventory().getContents()) {
                 location++;

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -1,13 +1,24 @@
 package io.servertap.api.v1;
 
 import io.javalin.http.Context;
+import io.javalin.http.InternalServerErrorResponse;
 import io.servertap.PluginEntrypoint;
+import io.servertap.api.v1.models.ItemStack;
 import io.servertap.api.v1.models.Player;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
+import de.tr7zw.nbtapi.NBTEntity;
+import de.tr7zw.nbtapi.NBTFile;
+import de.tr7zw.nbtapi.NBTListCompound;
+import de.tr7zw.nbtapi.data.PlayerData;
+import de.tr7zw.nbtapi.plugin.NBTAPI;
+
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.UUID;
 
 public class PlayerApi {
 
@@ -80,7 +91,7 @@ public class PlayerApi {
             p.setBanned(player.isBanned());
             p.setOp(player.isOp());
 
-            if(PluginEntrypoint.getEconomy() != null){
+            if (PluginEntrypoint.getEconomy() != null) {
                 p.setBalance(PluginEntrypoint.getEconomy().getBalance(offlinePlayers[i]));
             }
 
@@ -91,4 +102,50 @@ public class PlayerApi {
         ctx.json(players);
     }
 
+    public static void getPlayerInv(Context ctx) {
+        if (ctx.formParam("uuid") == null || ctx.formParam("world") == null) {
+            // TODO: Move to Constants
+            throw new InternalServerErrorResponse("Missing uuid and/or world");
+        }
+        ArrayList<ItemStack> inv = new ArrayList<ItemStack>();
+        org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.formParam("uuid")));
+        if (player != null) {
+            Integer location = -1;
+            for (org.bukkit.inventory.ItemStack itemStack : player.getInventory().getContents()) {
+                location++;
+                if (itemStack != null) {
+                    ItemStack itemObj = new ItemStack();
+                    // TODO: handle item namespaces other than minecraft: It's fine right now as there seem to be no forge + Paper servers
+                    itemObj.setId("minecraft:" + itemStack.getType().toString().toLowerCase());
+                    itemObj.setCount(Integer.valueOf(itemStack.getAmount()));
+                    itemObj.setSlot(location);
+                    inv.add(itemObj);
+                }
+            }
+            ctx.json(inv);
+        } else {
+            try {
+                String playerDatPath = Paths.get(new File("./").getAbsolutePath(), ctx.formParam("world"), "playerdata", ctx.formParam("uuid") + ".dat").toString();
+                File playerfile = new File(playerDatPath);
+                if(!playerfile.exists()){
+                    throw new InternalServerErrorResponse("Player file cannot be found");
+                }
+                NBTFile playerFile = new NBTFile(playerfile);
+
+                for (NBTListCompound item : playerFile.getCompoundList("Inventory")) {
+                    ItemStack itemObj = new ItemStack();
+                    itemObj.setId(item.getString("id"));
+                    itemObj.setCount(item.getInteger("Count"));
+                    itemObj.setSlot(item.getInteger("Slot"));
+                    inv.add(itemObj);
+                }
+
+                ctx.json(inv);
+            } catch (Exception e) {
+                Bukkit.getLogger().warning(e.getMessage());
+                throw new InternalServerErrorResponse("A problem occured when attempting to parse the user file");
+            }
+        }
+
+    }
 }

--- a/src/main/java/io/servertap/api/v1/models/ItemStack.java
+++ b/src/main/java/io/servertap/api/v1/models/ItemStack.java
@@ -1,0 +1,54 @@
+package io.servertap.api.v1.models;
+
+import com.google.gson.annotations.Expose;
+
+public class ItemStack {
+    
+    @Expose
+    private Integer count = null;
+
+    @Expose
+    private Integer slot = null;
+
+    @Expose
+    private String id = null;
+
+    public ItemStack slot(Integer slot) {
+        this.slot = slot;
+        return this;
+    }
+
+    public void setSlot(Integer slot){
+        this.slot = slot;
+    }
+
+    public Integer getSlot(){
+        return this.slot;
+    }
+
+    public ItemStack id(String id){
+        this.id = id;
+        return this;
+    }
+
+    public void setId(String id){
+        this.id = id;
+    }
+
+    public String getId(){
+        return this.id;
+    }
+
+    public ItemStack count(Integer count){
+        this.count = count;
+        return this;
+    }
+
+    public void setCount(Integer count){
+        this.count = count;
+    }
+
+    public Integer getCount(){
+        return this.count;
+    }
+}


### PR DESCRIPTION
Add the ability to read the inventory data about any player regardless of their online status.

***It is important to note that this feature is currently incompatible with custom forge items as it appears that bukkit itemstack can't track custom item id namespaces*** for the time being any custom forge items will appear as `minecraft:pluginName:itemname` this will likely be incompatible with expected namespacing. Once a working implication of a hybrid bukkit/forge server appears work will begin to make this feature compatible.