### PR TITLE
Add slf4j-jdk14 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
           <artifactId>item-nbt-api-plugin</artifactId>
           <version>2.3.1</version>
         </dependency>
+
+        <!-- logging framework -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.25</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Needed when this isn't already in the classpath, as is the case for normal Bukkit/Spigot servers.

```java
[23:31:23] [Server thread/INFO]: [ServerTap] Enabling ServerTap v0.0.3-SNAPSHOT
[23:31:23] [Server thread/WARN]: SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[23:31:23] [Server thread/WARN]: SLF4J: Defaulting to no-operation (NOP) logger implementation
[23:31:23] [Server thread/WARN]: SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[23:31:23] [Server thread/WARN]: -------------------------------------------------------------------

-------------------------------------------------------------------
Missing dependency 'Slf4j simple'. Add the dependency.

pom.xml:
<dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-simple</artifactId>
    <version>1.7.28</version>
</dependency>

build.gradle:
compile "org.slf4j:slf4j-simple:1.7.28"

Find the latest version here:
https://search.maven.org/search?q=g%3Aorg.slf4j+AND+a%3Aslf4j-simple
-------------------------------------------------------------------
```