### PR TITLE
Remove dependency on Paper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
     <repositories>
         <repository>
-            <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <id>spigotmc</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
@@ -37,8 +37,8 @@
     <dependencies>
         <!-- Minecraft plugin -->
         <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
+            <groupId>org.bukkit</groupId>
+            <artifactId>bukkit</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/io/servertap/Lag.java
+++ b/src/main/java/io/servertap/Lag.java
@@ -1,0 +1,35 @@
+package io.servertap;
+
+public class Lag implements Runnable {
+
+    private static final long[] TICKS = new long[600];
+    private static int TICK_COUNT = 0;
+
+    public static String getTPSString() {
+        try {
+            double tpsDouble = getTPS();
+            if (tpsDouble > 19.5) tpsDouble = 20;
+            String tps = Double.toString(tpsDouble);
+            return tps.length() > 4 ? tps.substring(0, 4) : tps;
+        } catch (Exception e) {
+            return "3.14";
+        }
+    }
+
+    public static double getTPS() {
+        return getTPS(100);
+    }
+
+    public static double getTPS(int ticks) {
+        if (TICK_COUNT < ticks) return 20;
+        int target = (TICK_COUNT - 1 - ticks) % TICKS.length;
+        long elapsed = System.currentTimeMillis() - TICKS[target];
+        return ticks / (elapsed / 1000d);
+    }
+
+    public void run() {
+        TICKS[(TICK_COUNT % TICKS.length)] = System.currentTimeMillis();
+        TICK_COUNT += 1;
+    }
+
+}

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -29,6 +29,8 @@ public class PluginEntrypoint extends JavaPlugin {
         FileConfiguration bukkitConfig = getConfig();
         setupEconomy();
 
+        Bukkit.getScheduler().runTaskTimer(this, new Lag(), 100, 1);
+
         // Get the current class loader.
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import io.javalin.http.Context;
 import io.javalin.http.NotFoundResponse;
 import io.javalin.plugin.openapi.annotations.*;
+import io.servertap.Lag;
 import io.servertap.api.v1.models.*;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -52,15 +53,9 @@ public class ServerApi {
         server.setVersion(bukkitServer.getVersion());
         server.setBukkitVersion(bukkitServer.getBukkitVersion());
         server.setWhitelistedPlayers(getWhitelist());
-        // Probably a better way to do this
-        DecimalFormat df = new DecimalFormat("#.##");
-        // Possibly add 5m and 15m in the future?
-        if (bukkitServer.getTPS().length > 0) {
-            server.setTps(df.format(bukkitServer.getTPS()[0]));
-        } else {
-            server.setTps("0.0");
-        }
 
+        // Possibly add 5m and 15m in the future?
+        server.setTps(Lag.getTPSString());
 
         // Get the list of IP bans
         Set<ServerBan> bannedIps = new HashSet<>();


### PR DESCRIPTION
As of now, the project isn't Bukkit compatible. `Server#getTPS` isn't a part of Bukkit, thus `MethodNotFoundException`s happen on non-Paper servers when the `/server` route is requested.

Keeping the server dependency on Bukkit is a good practice to make sure the project stays Bukkit compatible.