### PR TITLE
Added a top-level /economy route endpoint, issue #28

### DIFF
--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -8,6 +8,7 @@ public class Constants {
     public static final String VAULT_MISSING = "Vault not found. Related functionality disabled";
     public static final String VAULT_MISSING_PAY_PARAMS = "Missing uuid and/or amount";
     public static final String VAULT_GREATER_THAN_ZERO = "You must use a value greater than zero";
+    public static final String ECONOMY_PLUGIN_MISSING = "Missing economy plugin";
 
     // Player Related Messages
     public static final String PLAYER_MISSING_PARAMS = "Missing uuid and/or world";

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -81,6 +81,7 @@ public class PluginEntrypoint extends JavaPlugin {
                 // Economy routes
                 post("economy/pay", EconomyApi::playerPay);
                 post("economy/debit", EconomyApi::playerDebit);
+                get("economy", EconomyApi::getEconomyPluginInformation);
 
                 // Plugin routes
                 get("plugins", ServerApi::listPlugins);

--- a/src/main/java/io/servertap/api/v1/EconomyApi.java
+++ b/src/main/java/io/servertap/api/v1/EconomyApi.java
@@ -1,8 +1,10 @@
 package io.servertap.api.v1;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import io.javalin.plugin.openapi.annotations.*;
+import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
@@ -13,10 +15,44 @@ import io.servertap.PluginEntrypoint;
 
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class EconomyApi {
+
     private enum TransactionType {
         PAY, DEBIT
+    }
+
+    @OpenApi(
+            path = "/v1/economy",
+            method = HttpMethod.GET,
+            summary = "Economy plugin information",
+            tags = {"Economy"},
+            responses = {
+                    @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
+                    @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
+            }
+    )
+
+    public static void getEconomyPluginInformation(Context ctx){
+        Plugin econPlugin;
+        if (PluginEntrypoint.getEconomy() == null){
+            throw new InternalServerErrorResponse(Constants.VAULT_MISSING);
+        } else{
+            RegisteredServiceProvider<Economy> rsp = Bukkit.getServer().getServicesManager().getRegistration(Economy.class);
+            if (rsp == null) {
+                throw new InternalServerErrorResponse(Constants.ECONOMY_PLUGIN_MISSING);
+            }
+            econPlugin = rsp.getPlugin();
+        }
+
+        io.servertap.api.v1.models.Plugin plugin = new io.servertap.api.v1.models.Plugin();
+        plugin.setName(econPlugin.getName());
+        plugin.setEnabled(econPlugin.isEnabled());
+        plugin.setVersion(econPlugin.getDescription().getVersion());
+
+        ctx.json(plugin);
     }
 
     @OpenApi(


### PR DESCRIPTION
The added GET /economy endpoint returns information about the servers economy plugin. With the following syntax:
```
{
    "name": "Gringotts",
    "enabled": true,
    "version": "2.11.1-SNAPSHOT"
}
```