### PR TITLE
Update logging framework to latest + add missing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,19 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.30</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Upon download on the latest available jar in releases going to /server presents a 500 error.
This is due to 2 missing dependencies (this is reported in the console) I have added these dependancies and updated them to the latest stable release with no breaking changes.