### PR TITLE
Move whitelist routes under /server

### DIFF
--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -16,6 +16,12 @@ public class Constants {
     public static final String PLAYER_INV_PARSE_FAIL = "A problem occured when attempting to parse the user file";
     public static final String PLAYER_NOT_FOUND = "Player cannot be found";
 
+    //Whitelist Related Messages
+    public static final String WHITELIST_MISSING_PARAMS = "Missing one of uuid or username";
+    public static final String WHITELIST_NAME_NOT_FOUND = "Player name doesn't exist";
+    public static final String WHITELIST_UUID_NOT_FOUND = "Player UUID doesn't exist";
+    public static final String WHITELIST_MOJANG_API_FAIL = "Failed to access Mojang API";
+
     // World messages
     public static final String WORLD_NOT_FOUND = "World cannot be found";
 }

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -63,6 +63,8 @@ public class PluginEntrypoint extends JavaPlugin {
                 get("server/ops", ServerApi::getOps);
                 post("server/ops", ServerApi::opPlayer);
                 delete("server/ops", ServerApi::deopPlayer);
+                get("server/whitelist", ServerApi::whitelistGet);
+                post("server/whitelist", ServerApi::whitelistPost);
                 get("worlds", ServerApi::worldsGet);
                 post("worlds/save", ServerApi::saveAllWorlds);
                 get("worlds/:uuid", ServerApi::worldGet);
@@ -78,10 +80,6 @@ public class PluginEntrypoint extends JavaPlugin {
                 get("players/all", PlayerApi::offlinePlayersGet);
                 get("players/:uuid", PlayerApi::playerGet);
                 get("players/:playerUuid/:worldUuid/inventory", PlayerApi::getPlayerInv);
-
-                // Whitelist routes
-                get("whitelist", ServerApi::whitelistGet);
-                post("whitelist", ServerApi::whitelistPost);
 
                 // Economy routes
                 post("economy/pay", EconomyApi::playerPay);

--- a/src/main/java/io/servertap/mojang/api/MojangApiService.java
+++ b/src/main/java/io/servertap/mojang/api/MojangApiService.java
@@ -1,0 +1,106 @@
+package io.servertap.mojang.api;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.servertap.Constants;
+import io.servertap.mojang.api.models.NameChange;
+import io.servertap.mojang.api.models.NameHistory;
+import io.servertap.mojang.api.models.PlayerInfo;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class MojangApiService {
+	private static final String getUuidResource = "https://api.mojang.com/users/profiles/minecraft/%s";
+	private static final String getNameHistoryResource = "https://api.mojang.com/user/profiles/%s/names";
+
+	public static String getUuid(String username) throws IOException {
+		Gson gson = new Gson();
+
+		ApiResponse apiResponse = getApiResponse(String.format(getUuidResource, username));
+		if(apiResponse.getHttpStatus() == HttpURLConnection.HTTP_NO_CONTENT) {
+			throw new IllegalArgumentException("The given username was not found by the Mojang API.");
+		}
+
+		return gson.fromJson(apiResponse.getContent(), PlayerInfo.class).getId();
+	}
+
+	public static List<NameChange> getNameHistory(String uuid) throws IOException {
+		Type listType = new TypeToken<List<NameChange>>() {}.getType();
+		Gson gson = new Gson();
+
+		//This API call doesn't accept UUIDS with dashes
+		ApiResponse apiResponse = getApiResponse(String.format(getNameHistoryResource, uuid).replace("-", ""));
+		if(apiResponse.getHttpStatus() == HttpURLConnection.HTTP_BAD_REQUEST ||
+			apiResponse.getHttpStatus() == HttpURLConnection.HTTP_NO_CONTENT) {
+			throw new IllegalArgumentException("The given uuid was not found by the Mojang API.");
+		}
+
+		return gson.fromJson(apiResponse.getContent(), listType);
+	}
+
+	private static ApiResponse getApiResponse(String resource) throws IOException {
+		try {
+			String responseContent;
+
+			URL url = new URL(resource);
+			HttpURLConnection http = (HttpURLConnection)url.openConnection();
+			http.setRequestMethod("GET");
+			http.setDoInput(true);
+
+			http.connect();
+
+			if(http.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST) {
+				return new ApiResponse("", http.getResponseCode());
+			}
+
+			try(InputStream is = http.getInputStream()) {
+				responseContent = new BufferedReader(new InputStreamReader(is)).lines().collect(Collectors.joining("\n"));
+			}
+
+			return new ApiResponse(responseContent, http.getResponseCode());
+		} catch (MalformedURLException ignored) {
+			throw new IllegalArgumentException("The given resource string is not a valid URL.");
+		}
+	}
+
+	private static <T> ApiResponse getApiResponse(String resource, T requestData) {
+		throw new UnsupportedOperationException("Not implemented yet.");
+	}
+
+	private static class ApiResponse {
+		private String content;
+		private int httpStatus;
+
+		public ApiResponse(String content, int httpStatus) {
+			setContent(content);
+			setHttpStatus(httpStatus);
+		}
+
+		public String getContent() {
+			return content;
+		}
+
+		public void setContent(String content) {
+			this.content = content;
+		}
+
+		public int getHttpStatus() {
+			return httpStatus;
+		}
+
+		public void setHttpStatus(int httpStatus) {
+			this.httpStatus = httpStatus;
+		}
+	}
+}

--- a/src/main/java/io/servertap/mojang/api/models/NameChange.java
+++ b/src/main/java/io/servertap/mojang/api/models/NameChange.java
@@ -1,0 +1,27 @@
+package io.servertap.mojang.api.models;
+
+public class NameChange {
+	private String name;
+	private long changedToAt;
+
+	public NameChange(String name, long changedToAt) {
+		setName(name);
+		setChangedToAt(changedToAt);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public long getChangedToAt() {
+		return changedToAt;
+	}
+
+	public void setChangedToAt(long changedToAt) {
+		this.changedToAt = changedToAt;
+	}
+}

--- a/src/main/java/io/servertap/mojang/api/models/NameHistory.java
+++ b/src/main/java/io/servertap/mojang/api/models/NameHistory.java
@@ -1,0 +1,19 @@
+package io.servertap.mojang.api.models;
+
+import java.util.List;
+
+public class NameHistory {
+	private List<NameChange> nameChanges;
+
+	public NameHistory(List<NameChange> nameChanges) {
+		setNameChanges(nameChanges);
+	}
+
+	public List<NameChange> getNameChanges() {
+		return nameChanges;
+	}
+
+	public void setNameChanges(List<NameChange> nameChanges) {
+		this.nameChanges = nameChanges;
+	}
+}

--- a/src/main/java/io/servertap/mojang/api/models/PlayerInfo.java
+++ b/src/main/java/io/servertap/mojang/api/models/PlayerInfo.java
@@ -1,0 +1,27 @@
+package io.servertap.mojang.api.models;
+
+public class PlayerInfo {
+	private String id;
+	private String name;
+
+	public PlayerInfo(String id, String name) {
+		setId(id);
+		setName(name);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}


### PR DESCRIPTION
Moved whitelist routes under /server and allowed users of the API to whitelist by either username or uuid. The missing parameter will be filled in with a call to the Mojang API if necessary.