### PR TITLE
Added bStats integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,13 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.30</version>
         </dependency>
-
+        <!-- BStats Integration -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>1.7</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -126,7 +132,13 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>
-                    <!-- put your configurations here -->
+                    <relocations>
+                      <relocation>
+                        <pattern>org.bstats</pattern>
+                        <!-- Replace this with your package! -->
+                        <shadedPattern>your.package</shadedPattern>
+                      </relocation>
+                    </relocations>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bstats.bukkit.Metrics;
 
 import java.util.logging.Logger;
 
@@ -26,6 +27,9 @@ public class PluginEntrypoint extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Tell bStats what plugin this is
+        Metrics metrics = new Metrics(this, 9492);
+
         saveDefaultConfig();
         FileConfiguration bukkitConfig = getConfig();
         setupEconomy();


### PR DESCRIPTION
bStats is a system that allows us to get anonymized statistics about the servers who use our plugin. It is built into Spigot/Paper and requires no dependencies. If this is something that you are uncomfortable with, you can opt-out by modifying `/plugins/bStats/config.yml`.