### PR TITLE
Add ItemMeta to inventory entries

### DIFF
--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -177,6 +177,7 @@ public class PlayerApi {
                     itemObj.setId("minecraft:" + itemStack.getType().toString().toLowerCase());
                     itemObj.setCount(Integer.valueOf(itemStack.getAmount()));
                     itemObj.setSlot(location);
+                    itemObj.setItemMeta(itemStack.getItemMeta().serialize());
                     inv.add(itemObj);
                 }
             }
@@ -206,6 +207,7 @@ public class PlayerApi {
                     itemObj.setId(item.getString("id"));
                     itemObj.setCount(item.getInteger("Count"));
                     itemObj.setSlot(item.getInteger("Slot"));
+                    itemObj.setItemMeta(itemStack.getItemMeta().serialize());
                     inv.add(itemObj);
                 }
 

--- a/src/main/java/io/servertap/api/v1/models/ItemStack.java
+++ b/src/main/java/io/servertap/api/v1/models/ItemStack.java
@@ -1,5 +1,6 @@
 package io.servertap.api.v1.models;
 
+import java.util.Map;
 import com.google.gson.annotations.Expose;
 
 public class ItemStack {
@@ -13,7 +14,10 @@ public class ItemStack {
     @Expose
     private String id = null;
 
-    public ItemStack slot(Integer slot) {
+    @Expose
+    private Map<String,Object> itemMeta = null;
+    
+    public ItemStack slot(Integer slot){
         this.slot = slot;
         return this;
     }
@@ -38,6 +42,11 @@ public class ItemStack {
     public String getId(){
         return this.id;
     }
+
+    public void setItemMeta(Map<String,Object> itemMeta){
+        this.itemMeta = itemMeta;
+    }
+
 
     public ItemStack count(Integer count){
         this.count = count;


### PR DESCRIPTION
This adds an itemMeta key to each item slot to show metadata such as enchantments and durability.