### PR TITLE
Implement command responses for /server/exec

### DIFF
--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -31,5 +31,6 @@ public class Constants {
 
     // Command Execution messages
     public static final String COMMAND_PAYLOAD_MISSING = "Missing Command";
-    public static final String COMMAND_GENERIC_ERROR = "An error occured while executing command";
+    public static final String COMMAND_GENERIC_ERROR = "An error occurred while executing command";
+
 }

--- a/src/main/java/io/servertap/ServerExecCommandSender.java
+++ b/src/main/java/io/servertap/ServerExecCommandSender.java
@@ -30,7 +30,7 @@ public class ServerExecCommandSender implements ConsoleCommandSender {
     public CompletableFuture<String> executeCommand(String command, long messagingTime, TimeUnit messagingUnit) {
         Future<Boolean> commandFuture = Bukkit.getScheduler().callSyncMethod(
                 Bukkit.getPluginManager().getPlugin("ServerTap"),
-                () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
+                () -> Bukkit.dispatchCommand(this, command)
         );
 
         CompletableFuture<String> future = new CompletableFuture<>();

--- a/src/main/java/io/servertap/ServerExecCommandSender.java
+++ b/src/main/java/io/servertap/ServerExecCommandSender.java
@@ -5,8 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.conversations.Conversation;
-import org.bukkit.conversations.ConversationAbandonedEvent;
+import org.bukkit.command.RemoteConsoleCommandSender;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
@@ -20,7 +19,7 @@ import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.concurrent.*;
 
-public class ServerExecCommandSender implements ConsoleCommandSender {
+public class ServerExecCommandSender implements RemoteConsoleCommandSender {
 
     private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
     private static final ConsoleCommandSender CONSOLE_COMMAND_SENDER = Bukkit.getConsoleSender();
@@ -140,31 +139,6 @@ public class ServerExecCommandSender implements ConsoleCommandSender {
     @Override
     public Server getServer() {
         return CONSOLE_COMMAND_SENDER.getServer();
-    }
-
-    @Override
-    public void abandonConversation(Conversation arg0) {
-        CONSOLE_COMMAND_SENDER.abandonConversation(arg0);
-    }
-
-    @Override
-    public void abandonConversation(Conversation c, ConversationAbandonedEvent e) {
-        CONSOLE_COMMAND_SENDER.abandonConversation(c, e);
-    }
-
-    @Override
-    public void acceptConversationInput(String input) {
-        CONSOLE_COMMAND_SENDER.acceptConversationInput(input);
-    }
-
-    @Override
-    public boolean beginConversation(Conversation c) {
-        return CONSOLE_COMMAND_SENDER.beginConversation(c);
-    }
-
-    @Override
-    public boolean isConversing() {
-        return CONSOLE_COMMAND_SENDER.isConversing();
     }
 
     public void sendRawMessage(String raw) {

--- a/src/main/java/io/servertap/ServerExecCommandSender.java
+++ b/src/main/java/io/servertap/ServerExecCommandSender.java
@@ -1,0 +1,189 @@
+package io.servertap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.conversations.Conversation;
+import org.bukkit.conversations.ConversationAbandonedEvent;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+public class ServerExecCommandSender implements ConsoleCommandSender {
+
+    private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
+    private static final ConsoleCommandSender CONSOLE_COMMAND_SENDER = Bukkit.getConsoleSender();
+
+    private final StringJoiner messageBuffer = new StringJoiner("\n");
+
+    public CompletableFuture<String> executeCommand(String command, long messagingTime, TimeUnit messagingUnit) {
+        Future<Boolean> commandFuture = Bukkit.getScheduler().callSyncMethod(
+                Bukkit.getPluginManager().getPlugin("ServerTap"),
+                () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command)
+        );
+
+        CompletableFuture<String> future = new CompletableFuture<>();
+        EXECUTOR.schedule(() -> {
+            try {
+                commandFuture.get(5, TimeUnit.SECONDS);
+                future.complete(messageBuffer.toString());
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                future.completeExceptionally(new RuntimeException(Constants.COMMAND_GENERIC_ERROR, e));
+            }
+        }, messagingTime, messagingUnit);
+        return future;
+    }
+
+    @Override
+    public void sendMessage(@NotNull String message) {
+        //TODO should probably cover other control characters besides just section signs
+        messageBuffer.add(ChatColor.stripColor(message));
+    }
+
+    @Override
+    public void sendMessage(String[] messages) {
+        for (String msg : messages)
+            sendMessage(msg);
+    }
+
+    // Paper
+    public void sendMessage(@Nullable UUID uuid, @NotNull String s) {
+        sendMessage(s);
+    }
+
+    // Paper
+    public void sendMessage(@Nullable UUID uuid, @NotNull String[] strings) {
+        sendMessage(strings);
+    }
+
+    @Override
+    public PermissionAttachment addAttachment(Plugin plugin) {
+        return CONSOLE_COMMAND_SENDER.addAttachment(plugin);
+    }
+
+    @Override
+    public PermissionAttachment addAttachment(Plugin plugin, int arg1) {
+        return CONSOLE_COMMAND_SENDER.addAttachment(plugin, arg1);
+    }
+
+    @Override
+    public PermissionAttachment addAttachment(Plugin plugin, String arg1, boolean arg2) {
+        return CONSOLE_COMMAND_SENDER.addAttachment(plugin, arg1, arg2);
+    }
+
+    @Override
+    public PermissionAttachment addAttachment(Plugin plugin, String arg1, boolean arg2, int arg3) {
+        return CONSOLE_COMMAND_SENDER.addAttachment(plugin, arg1, arg2, arg3);
+    }
+
+    @Override
+    public Set<PermissionAttachmentInfo> getEffectivePermissions() {
+        return CONSOLE_COMMAND_SENDER.getEffectivePermissions();
+    }
+
+    @Override
+    public boolean hasPermission(String arg0) {
+        return CONSOLE_COMMAND_SENDER.hasPermission(arg0);
+    }
+
+    @Override
+    public boolean hasPermission(Permission arg0) {
+        return CONSOLE_COMMAND_SENDER.hasPermission(arg0);
+    }
+
+    @Override
+    public boolean isPermissionSet(String arg0) {
+        return CONSOLE_COMMAND_SENDER.isPermissionSet(arg0);
+    }
+
+    @Override
+    public boolean isPermissionSet(Permission arg0) {
+        return CONSOLE_COMMAND_SENDER.isPermissionSet(arg0);
+    }
+
+    @Override
+    public void recalculatePermissions() {
+        CONSOLE_COMMAND_SENDER.recalculatePermissions();
+    }
+
+    @Override
+    public void removeAttachment(PermissionAttachment arg0) {
+        CONSOLE_COMMAND_SENDER.removeAttachment(arg0);
+    }
+
+    @Override
+    public boolean isOp() {
+        return CONSOLE_COMMAND_SENDER.isOp();
+    }
+
+    @Override
+    public void setOp(boolean arg0) {
+        CONSOLE_COMMAND_SENDER.setOp(arg0);
+    }
+
+    @Override
+    public String getName() {
+        return CONSOLE_COMMAND_SENDER.getName();
+    }
+
+    @Override
+    public Server getServer() {
+        return CONSOLE_COMMAND_SENDER.getServer();
+    }
+
+    @Override
+    public void abandonConversation(Conversation arg0) {
+        CONSOLE_COMMAND_SENDER.abandonConversation(arg0);
+    }
+
+    @Override
+    public void abandonConversation(Conversation c, ConversationAbandonedEvent e) {
+        CONSOLE_COMMAND_SENDER.abandonConversation(c, e);
+    }
+
+    @Override
+    public void acceptConversationInput(String input) {
+        CONSOLE_COMMAND_SENDER.acceptConversationInput(input);
+    }
+
+    @Override
+    public boolean beginConversation(Conversation c) {
+        return CONSOLE_COMMAND_SENDER.beginConversation(c);
+    }
+
+    @Override
+    public boolean isConversing() {
+        return CONSOLE_COMMAND_SENDER.isConversing();
+    }
+
+    public void sendRawMessage(String raw) {
+        CONSOLE_COMMAND_SENDER.sendRawMessage(raw);
+    }
+
+    // Paper
+    public void sendRawMessage(@Nullable UUID uuid, @NotNull String raw) {
+        CONSOLE_COMMAND_SENDER.sendRawMessage(uuid, raw);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public CommandSender.Spigot spigot() {
+        try {
+            return (CommandSender.Spigot) CommandSender.class.getMethod("spigot").invoke(CONSOLE_COMMAND_SENDER);
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -677,7 +677,7 @@ public class ServerApi {
         }
 
         String timeRaw = ctx.formParam("time");
-        long time = timeRaw != null ? Long.parseLong(timeRaw) : 1000;
+        long time = timeRaw != null ? Long.parseLong(timeRaw) : 0;
         if (time < 0) time = 0;
 
         ctx.result(new ServerExecCommandSender().executeCommand(command, time, TimeUnit.MILLISECONDS));

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -655,7 +655,8 @@ public class ServerApi {
     @OpenApi(
         path = "/v1/server/exec",
         method = HttpMethod.POST,
-        summary = "Executes a command on the server from the console, returning it's output.",
+        summary = "Executes a command on the server from the console, returning it's output. Be aware that not all " +
+                "command executors will properly send their messages to the CommandSender, though, most do.",
         tags = {"Server"},
         headers = {
             @OpenApiParam(name = "key")


### PR DESCRIPTION
If request `Content-Type` is set to `application/json`, the response will be JSON encoded, plain otherwise

`time` param can optionally be specified to allow for catching command output from plugins that handle their commands asynchronously (such as DiscordSRV)

![](https://lol.scarsz.me/xAuSwO/chrome-1620167787.png)