### PR TITLE
Make error responses more RESTy

### DIFF
--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -33,4 +33,6 @@ public class Constants {
     public static final String COMMAND_PAYLOAD_MISSING = "Missing Command";
     public static final String COMMAND_GENERIC_ERROR = "An error occurred while executing command";
 
+    // General errors
+    public static final String INVALID_UUID = "Invalid UUID";
 }

--- a/src/main/java/io/servertap/api/v1/EconomyApi.java
+++ b/src/main/java/io/servertap/api/v1/EconomyApi.java
@@ -1,22 +1,21 @@
 package io.servertap.api.v1;
 
-import java.util.ArrayList;
-import java.util.UUID;
-
-import io.javalin.plugin.openapi.annotations.*;
-import net.milkbowl.vault.economy.Economy;
-import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-
+import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.InternalServerErrorResponse;
+import io.javalin.http.ServiceUnavailableResponse;
+import io.javalin.plugin.openapi.annotations.*;
 import io.servertap.Constants;
 import io.servertap.PluginEntrypoint;
-
+import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.UUID;
 
 public class EconomyApi {
 
@@ -30,7 +29,7 @@ public class EconomyApi {
             summary = "Economy plugin information",
             tags = {"Economy"},
             headers = {
-            @OpenApiParam(name = "key")
+                    @OpenApiParam(name = "key")
             },
             responses = {
                     @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
@@ -38,11 +37,11 @@ public class EconomyApi {
             }
     )
 
-    public static void getEconomyPluginInformation(Context ctx){
+    public static void getEconomyPluginInformation(Context ctx) {
         Plugin econPlugin;
-        if (PluginEntrypoint.getEconomy() == null){
+        if (PluginEntrypoint.getEconomy() == null) {
             throw new InternalServerErrorResponse(Constants.VAULT_MISSING);
-        } else{
+        } else {
             RegisteredServiceProvider<Economy> rsp = Bukkit.getServer().getServicesManager().getRegistration(Economy.class);
             if (rsp == null) {
                 throw new InternalServerErrorResponse(Constants.ECONOMY_PLUGIN_MISSING);
@@ -59,44 +58,44 @@ public class EconomyApi {
     }
 
     @OpenApi(
-        path = "/v1/economy/pay",
-        method = HttpMethod.POST,
-        summary = "Pay a player",
-        description = "Deposits the provided amount into the player's Vault",
-        tags = {"Economy"},
-        headers = {
-        @OpenApiParam(name = "key")
-        },
-        formParams = {
-            @OpenApiFormParam(name = "uuid"),
-            @OpenApiFormParam(name = "amount", type = Double.class)
-        },
-        responses = {
-            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
-            @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
-        }
+            path = "/v1/economy/pay",
+            method = HttpMethod.POST,
+            summary = "Pay a player",
+            description = "Deposits the provided amount into the player's Vault",
+            tags = {"Economy"},
+            headers = {
+                    @OpenApiParam(name = "key")
+            },
+            formParams = {
+                    @OpenApiFormParam(name = "uuid"),
+                    @OpenApiFormParam(name = "amount", type = Double.class)
+            },
+            responses = {
+                    @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
+                    @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
+            }
     )
     public static void playerPay(Context ctx) {
         accountManager(ctx, TransactionType.PAY);
     }
 
     @OpenApi(
-        path = "/v1/economy/debit",
-        method = HttpMethod.POST,
-        summary = "Debit a player",
-        description = "Withdraws the provided amount out of the player's Vault",
-        tags = {"Economy"},
-        headers = {
-        @OpenApiParam(name = "key")
-        },
-        formParams = {
-            @OpenApiFormParam(name = "uuid"),
-            @OpenApiFormParam(name = "amount", type = Double.class)
-        },
-        responses = {
-            @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
-            @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
-        }
+            path = "/v1/economy/debit",
+            method = HttpMethod.POST,
+            summary = "Debit a player",
+            description = "Withdraws the provided amount out of the player's Vault",
+            tags = {"Economy"},
+            headers = {
+                    @OpenApiParam(name = "key")
+            },
+            formParams = {
+                    @OpenApiFormParam(name = "uuid"),
+                    @OpenApiFormParam(name = "amount", type = Double.class)
+            },
+            responses = {
+                    @OpenApiResponse(status = "200", content = @OpenApiContent(type = "application/json")),
+                    @OpenApiResponse(status = "500", content = @OpenApiContent(type = "application/json"))
+            }
     )
     public static void playerDebit(Context ctx) {
         accountManager(ctx, TransactionType.DEBIT);
@@ -104,7 +103,7 @@ public class EconomyApi {
 
     private static void accountManager(Context ctx, TransactionType action) {
         if (ctx.formParam("uuid") == null || ctx.formParam("amount") == null) {
-            throw new InternalServerErrorResponse(Constants.VAULT_MISSING_PAY_PARAMS);
+            throw new BadRequestResponse(Constants.VAULT_MISSING_PAY_PARAMS);
         }
 
         if (PluginEntrypoint.getEconomy() == null) {
@@ -116,7 +115,7 @@ public class EconomyApi {
         double amount = Double.parseDouble(ctx.formParam("amount"));
 
         if (amount <= 0) { // Make sure pay amount is more than zero
-            throw new InternalServerErrorResponse(Constants.VAULT_GREATER_THAN_ZERO);
+            throw new BadRequestResponse(Constants.VAULT_GREATER_THAN_ZERO);
         }
 
         EconomyResponse response;

--- a/src/main/java/io/servertap/api/v1/EconomyApi.java
+++ b/src/main/java/io/servertap/api/v1/EconomyApi.java
@@ -2,8 +2,8 @@ package io.servertap.api.v1;
 
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
+import io.javalin.http.HttpResponseException;
 import io.javalin.http.InternalServerErrorResponse;
-import io.javalin.http.ServiceUnavailableResponse;
 import io.javalin.plugin.openapi.annotations.*;
 import io.servertap.Constants;
 import io.servertap.PluginEntrypoint;
@@ -15,6 +15,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class EconomyApi {
@@ -40,7 +41,7 @@ public class EconomyApi {
     public static void getEconomyPluginInformation(Context ctx) {
         Plugin econPlugin;
         if (PluginEntrypoint.getEconomy() == null) {
-            throw new InternalServerErrorResponse(Constants.VAULT_MISSING);
+            throw new HttpResponseException(424, Constants.VAULT_MISSING, new HashMap<>());
         } else {
             RegisteredServiceProvider<Economy> rsp = Bukkit.getServer().getServicesManager().getRegistration(Economy.class);
             if (rsp == null) {
@@ -107,10 +108,14 @@ public class EconomyApi {
         }
 
         if (PluginEntrypoint.getEconomy() == null) {
-            throw new InternalServerErrorResponse(Constants.VAULT_MISSING);
+            throw new HttpResponseException(424, Constants.VAULT_MISSING, new HashMap<>());
         }
 
-        OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(ctx.formParam("uuid")));
+        UUID playerUUID = ValidationUtils.safeUUID(ctx.formParam("uuid"));
+        if (playerUUID == null) {
+            throw new BadRequestResponse(Constants.INVALID_UUID);
+        }
+        OfflinePlayer player = Bukkit.getOfflinePlayer(playerUUID);
 
         double amount = Double.parseDouble(ctx.formParam("amount"));
 

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -162,7 +162,7 @@ public class PlayerApi {
     )
     public static void getPlayerInv(Context ctx) {
         if (ctx.pathParam("playerUuid").isEmpty() || ctx.pathParam("worldUuid").isEmpty()) {
-            throw new InternalServerErrorResponse(Constants.PLAYER_MISSING_PARAMS);
+            throw new BadRequestResponse(Constants.PLAYER_MISSING_PARAMS);
         }
         ArrayList<ItemStack> inv = new ArrayList<ItemStack>();
         org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.pathParam("playerUuid")));
@@ -197,7 +197,7 @@ public class PlayerApi {
                 );
                 File playerfile = new File(Paths.get(dataPath).toString());
                 if (!playerfile.exists()) {
-                    throw new InternalServerErrorResponse(Constants.PLAYER_NOT_FOUND);
+                    throw new NotFoundResponse(Constants.PLAYER_NOT_FOUND);
                 }
                 NBTFile playerFile = new NBTFile(playerfile);
 

--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -24,7 +24,7 @@ public class PlayerApi {
             summary = "Gets all currently online players",
             tags = {"Player"},
             headers = {
-            @OpenApiParam(name = "key")
+                    @OpenApiParam(name = "key")
             },
             responses = {
                     @OpenApiResponse(status = "200", content = @OpenApiContent(from = Player.class, isArray = true))
@@ -64,7 +64,7 @@ public class PlayerApi {
             summary = "Gets a specific online player by their UUID",
             tags = {"Player"},
             headers = {
-            @OpenApiParam(name = "key")
+                    @OpenApiParam(name = "key")
             },
             pathParams = {
                     @OpenApiParam(name = "uuid", description = "UUID of the player")
@@ -80,7 +80,12 @@ public class PlayerApi {
             throw new BadRequestResponse(Constants.PLAYER_UUID_MISSING);
         }
 
-        org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.pathParam("uuid")));
+        UUID playerUUID = ValidationUtils.safeUUID(ctx.pathParam("uuid"));
+        if (playerUUID == null) {
+            throw new BadRequestResponse(Constants.INVALID_UUID);
+        }
+
+        org.bukkit.entity.Player player = Bukkit.getPlayer(playerUUID);
 
         if (player == null) {
             throw new NotFoundResponse(Constants.PLAYER_NOT_FOUND);
@@ -111,7 +116,7 @@ public class PlayerApi {
             summary = "Gets all players that have ever joined the server ",
             tags = {"Player"},
             headers = {
-            @OpenApiParam(name = "key")
+                    @OpenApiParam(name = "key")
             },
             responses = {
                     @OpenApiResponse(status = "200", content = @OpenApiContent(from = io.servertap.api.v1.models.OfflinePlayer.class, isArray = true))
@@ -150,7 +155,7 @@ public class PlayerApi {
             summary = "Gets a specific online player's Inventory in the specified world",
             tags = {"Player"},
             headers = {
-            @OpenApiParam(name = "key")
+                    @OpenApiParam(name = "key")
             },
             pathParams = {
                     @OpenApiParam(name = "playerUuid", description = "UUID of the player"),
@@ -164,8 +169,18 @@ public class PlayerApi {
         if (ctx.pathParam("playerUuid").isEmpty() || ctx.pathParam("worldUuid").isEmpty()) {
             throw new BadRequestResponse(Constants.PLAYER_MISSING_PARAMS);
         }
+
+        UUID playerUUID = ValidationUtils.safeUUID(ctx.pathParam("playerUuid"));
+        if (playerUUID == null) {
+            throw new BadRequestResponse(Constants.INVALID_UUID);
+        }
+        UUID worldUUID = ValidationUtils.safeUUID(ctx.pathParam("worldUuid"));
+        if (worldUUID == null) {
+            throw new BadRequestResponse(Constants.INVALID_UUID);
+        }
+
         ArrayList<ItemStack> inv = new ArrayList<ItemStack>();
-        org.bukkit.entity.Player player = Bukkit.getPlayer(UUID.fromString(ctx.pathParam("playerUuid")));
+        org.bukkit.entity.Player player = Bukkit.getPlayer(playerUUID);
         if (player != null) {
             player.updateInventory();
             Integer location = -1;
@@ -175,7 +190,7 @@ public class PlayerApi {
                     ItemStack itemObj = new ItemStack();
                     // TODO: handle item namespaces other than minecraft: It's fine right now as there seem to be no forge + Paper servers
                     itemObj.setId("minecraft:" + itemStack.getType().toString().toLowerCase());
-                    itemObj.setCount(Integer.valueOf(itemStack.getAmount()));
+                    itemObj.setCount(itemStack.getAmount());
                     itemObj.setSlot(location);
                     inv.add(itemObj);
                 }
@@ -183,10 +198,10 @@ public class PlayerApi {
             ctx.json(inv);
         } else {
             try {
-                World bukWorld = Bukkit.getWorld(UUID.fromString(ctx.pathParam("worldUuid")));
+                World bukWorld = Bukkit.getWorld(worldUUID);
 
                 if (bukWorld == null) {
-                    throw new BadRequestResponse(Constants.WORLD_NOT_FOUND);
+                    throw new NotFoundResponse(Constants.WORLD_NOT_FOUND);
                 }
 
                 String dataPath = String.format(

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -1,10 +1,7 @@
 package io.servertap.api.v1;
 
 import com.google.gson.Gson;
-import io.javalin.http.BadRequestResponse;
-import io.javalin.http.Context;
-import io.javalin.http.InternalServerErrorResponse;
-import io.javalin.http.NotFoundResponse;
+import io.javalin.http.*;
 import io.javalin.plugin.json.JavalinJson;
 import io.javalin.plugin.openapi.annotations.*;
 import io.servertap.Constants;
@@ -485,7 +482,7 @@ public class ServerApi {
         String name = ctx.formParam("name");
 
         if(uuid == null && name == null) {
-            throw new InternalServerErrorResponse(Constants.WHITELIST_MISSING_PARAMS);
+            throw new BadRequestResponse(Constants.WHITELIST_MISSING_PARAMS);
         }
 
         //Check Mojang API for missing param
@@ -493,18 +490,18 @@ public class ServerApi {
             try {
                 uuid = MojangApiService.getUuid(name);
             } catch(IllegalArgumentException ignored) {
-                throw new InternalServerErrorResponse(Constants.WHITELIST_NAME_NOT_FOUND);
+                throw new NotFoundResponse(Constants.WHITELIST_NAME_NOT_FOUND);
             } catch(IOException ignored) {
-                throw new InternalServerErrorResponse(Constants.WHITELIST_MOJANG_API_FAIL);
+                throw new ServiceUnavailableResponse(Constants.WHITELIST_MOJANG_API_FAIL);
             }
         } else if (name == null) {
             try {
                 List<NameChange> nameHistory = MojangApiService.getNameHistory(uuid);
                 name = nameHistory.get(nameHistory.size() - 1).getName();
             } catch(IllegalArgumentException ignored) {
-                throw new InternalServerErrorResponse(Constants.WHITELIST_UUID_NOT_FOUND);
+                throw new NotFoundResponse(Constants.WHITELIST_UUID_NOT_FOUND);
             } catch(IOException ignored) {
-                throw new InternalServerErrorResponse(Constants.WHITELIST_MOJANG_API_FAIL);
+                throw new ServiceUnavailableResponse(Constants.WHITELIST_MOJANG_API_FAIL);
             }
         }
 
@@ -582,11 +579,11 @@ public class ServerApi {
         })
     public static void opPlayer(Context ctx) {
         if (ctx.formParam("playerUuid").isEmpty()) {
-            throw new InternalServerErrorResponse(Constants.PLAYER_MISSING_PARAMS);
+            throw new BadRequestResponse(Constants.PLAYER_MISSING_PARAMS);
         }
         org.bukkit.OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(ctx.formParam("playerUuid")));
         if (player == null) {
-            throw new InternalServerErrorResponse(Constants.PLAYER_NOT_FOUND);
+            throw new NotFoundResponse(Constants.PLAYER_NOT_FOUND);
         }
         player.setOp(true);
         ctx.json("success");
@@ -607,11 +604,11 @@ public class ServerApi {
     )
     public static void deopPlayer(Context ctx) {
         if (ctx.formParam("playerUuid").isEmpty()) {
-            throw new InternalServerErrorResponse(Constants.PLAYER_MISSING_PARAMS);
+            throw new BadRequestResponse(Constants.PLAYER_MISSING_PARAMS);
         }
         org.bukkit.OfflinePlayer player = Bukkit.getOfflinePlayer(UUID.fromString(ctx.formParam("playerUuid")));
         if (player == null) {
-            throw new InternalServerErrorResponse(Constants.PLAYER_NOT_FOUND);
+            throw new NotFoundResponse(Constants.PLAYER_NOT_FOUND);
         }
         player.setOp(false);
         ctx.json("success");
@@ -678,7 +675,7 @@ public class ServerApi {
     public static void postCommand(Context ctx) {
         String command = ctx.formParam("command");
         if (StringUtils.isBlank(command)) {
-            throw new InternalServerErrorResponse(Constants.COMMAND_PAYLOAD_MISSING);
+            throw new BadRequestResponse(Constants.COMMAND_PAYLOAD_MISSING);
         }
 
         String timeRaw = ctx.formParam("time");

--- a/src/main/java/io/servertap/api/v1/ValidationUtils.java
+++ b/src/main/java/io/servertap/api/v1/ValidationUtils.java
@@ -1,0 +1,15 @@
+package io.servertap.api.v1;
+
+import java.util.UUID;
+
+public class ValidationUtils {
+
+    public static UUID safeUUID(String input) {
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException iae) {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
I was torn on a couple of them, notably when the Mojang API fails you COULD do a `424` as defined in the WebDAV RFC but realistically there's nothing the _client_ can change about what they're doing to make the call succeed. If it's down, it's unavailable, so 503.

Likewise if there's no Economy plugin, that's a "server misconfiguration" sort of, so I did 500 for that.

Also sprinkled in a bunch of 404's when things aren't found, and 400's when the client made a mistake, missed a parameter, things like that.