### PR TITLE
Create and implement websocket with Player API

### DIFF
--- a/src/main/java/io/servertap/Constants.java
+++ b/src/main/java/io/servertap/Constants.java
@@ -35,6 +35,8 @@ public class Constants {
 
     // General errors
     public static final String INVALID_UUID = "Invalid UUID";
+    public static final String UNKNOWN_WEBSOCKET_COMMAND = "Unknown websocket command";
+    public static final String INTERNAL_SERVER_ERROR = "Internal server error";
 
     // PAPI Messages
     public static final String PAPI_MESSAGE_MISSING = "Missing message from request";

--- a/src/main/java/io/servertap/PluginEntrypoint.java
+++ b/src/main/java/io/servertap/PluginEntrypoint.java
@@ -7,6 +7,7 @@ import io.javalin.plugin.openapi.ui.SwaggerOptions;
 import io.servertap.api.v1.*;
 import io.servertap.api.v1.models.ConsoleLine;
 import io.servertap.api.v1.websockets.ConsoleListener;
+import io.servertap.api.v1.websockets.ConsoleWebsocketHandler;
 import io.servertap.api.v1.websockets.WebsocketHandler;
 import io.servertap.metrics.Metrics;
 import io.servertap.utils.GsonJsonMapper;
@@ -168,7 +169,7 @@ public class PluginEntrypoint extends JavaPlugin {
                     }
 
                     // fall through, failsafe
-                    ctx.status(401).result("Unauthorized key, reference the key existing in config.yml");
+                    ctx.status(401).result("Unauthorized key, reference the key in config.yml");
                 });
 
                 config.registerPlugin(new OpenApiPlugin(getOpenApiOptions()));
@@ -229,7 +230,8 @@ public class PluginEntrypoint extends JavaPlugin {
                 post("placeholders/replace", PAPIApi::replacePlaceholders);
 
                 // Websocket handler
-                ws("ws/console", WebsocketHandler::events);
+                ws("ws", WebsocketHandler::events);
+                ws("ws/console", ConsoleWebsocketHandler::events);
             });
         });
 

--- a/src/main/java/io/servertap/api/v1/websockets/ConsoleListener.java
+++ b/src/main/java/io/servertap/api/v1/websockets/ConsoleListener.java
@@ -2,7 +2,6 @@ package io.servertap.api.v1.websockets;
 
 import io.servertap.PluginEntrypoint;
 import io.servertap.api.v1.models.ConsoleLine;
-import io.servertap.api.v1.websockets.WebsocketHandler;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.Filter;
@@ -32,7 +31,7 @@ public class ConsoleListener implements Filter {
         line.setLoggerName(logEvent.getLoggerName());
 
         plugin.consoleBuffer.add(line);
-        WebsocketHandler.broadcast(line);
+        ConsoleWebsocketHandler.broadcast(line);
         return Result.NEUTRAL;
     }
 

--- a/src/main/java/io/servertap/api/v1/websockets/ConsoleWebsocketHandler.java
+++ b/src/main/java/io/servertap/api/v1/websockets/ConsoleWebsocketHandler.java
@@ -1,0 +1,97 @@
+package io.servertap.api.v1.websockets;
+
+import com.google.gson.Gson;
+import io.javalin.websocket.WsConfig;
+import io.javalin.websocket.WsContext;
+import io.servertap.Constants;
+import io.servertap.PluginEntrypoint;
+import io.servertap.api.v1.PlayerApi;
+import io.servertap.api.v1.ValidationUtils;
+import io.servertap.api.v1.models.ConsoleLine;
+import io.servertap.api.v1.models.ItemStack;
+import io.servertap.api.v1.models.OfflinePlayer;
+import io.servertap.api.v1.models.Player;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConsoleWebsocketHandler {
+
+    private final static Map<String, WsContext> subscribers = new ConcurrentHashMap<>();
+
+    public static void events(WsConfig ws) {
+        ws.onConnect(ctx -> {
+            subscribers.put(clientHash(ctx), ctx);
+
+            for (ConsoleLine line : PluginEntrypoint.instance.consoleBuffer) {
+                ctx.send(line);
+            }
+        });
+
+        // Unsubscribe clients that disconnect
+        ws.onClose(ctx -> {
+            subscribers.remove(clientHash(ctx));
+        });
+
+        // Unsubscribe any subscribers that error out
+        ws.onError(ctx -> {
+            subscribers.remove(clientHash(ctx));
+        });
+
+        // Allow sending of commands
+        ws.onMessage(ctx -> {
+            String cmd = ctx.message().trim();
+
+            if (!cmd.isEmpty()) {
+                if (cmd.startsWith("/")) {
+                    cmd = cmd.substring(1);
+                }
+
+                final String command = cmd;
+                Plugin pluginInstance = PluginEntrypoint.instance;
+
+                if (pluginInstance != null) {
+                    // Run the command on the main thread
+                    Bukkit.getScheduler().scheduleSyncDelayedTask(pluginInstance, () -> {
+
+                        try {
+                            CommandSender sender = Bukkit.getServer().getConsoleSender();
+                            Bukkit.dispatchCommand(sender, command);
+                        } catch (Exception e) {
+                            // Just warn about the issue
+                            Bukkit.getLogger().warning("Couldn't execute command over websocket");
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    /**
+     * Sends the specified message (as JSON) to all subscribed clients.
+     *
+     * @param message Object can be any Jackson/JSON serializable object
+     */
+    public static void broadcast(Object message) {
+        subscribers.values().stream().filter(ctx -> ctx.session.isOpen()).forEach(session -> {
+            session.send(message);
+        });
+    }
+
+    /**
+     * Generate a unique hash for this subscriber using its connection properties
+     *
+     * @param ctx
+     * @return String the hash
+     */
+    private static String clientHash(WsContext ctx) {
+        return String.format("sub-%s-%s", ctx.host(), ctx.getSessionId());
+    }
+}

--- a/src/main/java/io/servertap/api/v1/websockets/WebsocketHandler.java
+++ b/src/main/java/io/servertap/api/v1/websockets/WebsocketHandler.java
@@ -1,87 +1,103 @@
 package io.servertap.api.v1.websockets;
 
+import com.google.gson.Gson;
+import com.google.gson.annotations.Expose;
 import io.javalin.websocket.WsConfig;
 import io.javalin.websocket.WsContext;
+import io.servertap.Constants;
 import io.servertap.PluginEntrypoint;
+import io.servertap.api.v1.PlayerApi;
+import io.servertap.api.v1.ValidationUtils;
 import io.servertap.api.v1.models.ConsoleLine;
+import io.servertap.api.v1.models.ItemStack;
+import io.servertap.api.v1.models.OfflinePlayer;
+import io.servertap.api.v1.models.Player;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WebsocketHandler {
 
-    private final static Map<String, WsContext> subscribers = new ConcurrentHashMap<>();
+    private static final Gson gson = new Gson();
 
     public static void events(WsConfig ws) {
-        ws.onConnect(ctx -> {
-            subscribers.put(clientHash(ctx), ctx);
-
-            for (ConsoleLine line : PluginEntrypoint.instance.consoleBuffer) {
-                ctx.send(line);
-            }
-        });
-
-        // Unsubscribe clients that disconnect
-        ws.onClose(ctx -> {
-            subscribers.remove(clientHash(ctx));
-        });
-
-        // Unsubscribe any subscribers that error out
-        ws.onError(ctx -> {
-            subscribers.remove(clientHash(ctx));
-        });
-
-        // Allow sending of commands
         ws.onMessage(ctx -> {
             String cmd = ctx.message().trim();
 
             if (!cmd.isEmpty()) {
-
-                if (cmd.startsWith("/")) {
-                    cmd = cmd.substring(1);
-                }
-
-                final String command = cmd;
-                Plugin pluginInstance = PluginEntrypoint.instance;
-
-                if (pluginInstance != null) {
-                    // Run the command on the main thread
-                    Bukkit.getScheduler().scheduleSyncDelayedTask(pluginInstance, () -> {
-
-                        try {
-                            CommandSender sender = Bukkit.getServer().getConsoleSender();
-                            Bukkit.dispatchCommand(sender, command);
-                        } catch (Exception e) {
-                            // Just warn about the issue
-                            Bukkit.getLogger().warning("Couldn't execute command over websocket");
+                String[] args = cmd.split(" ");
+                try {
+                    switch (args[0]) {
+                        case "getPlayers" -> {
+                            List<Player> players = PlayerApi.playersGet();
+                            sendJsonMessageWithType(ctx, players, "getPlayers");
                         }
-                    });
+                        case "getPlayer" -> {
+                            if (args.length < 2) throw new IllegalArgumentException(Constants.PLAYER_UUID_MISSING);
+                            UUID uuid = ValidationUtils.safeUUID(args[1]);
+                            if (uuid == null) throw new IllegalArgumentException(Constants.INVALID_UUID);
+                            Player p = PlayerApi.playerGet(uuid);
+                            sendJsonMessageWithType(ctx, p, "getPlayer");
+                        }
+                        case "getAllPlayers" -> {
+                            List<OfflinePlayer> offlinePlayers = PlayerApi.offlinePlayersGet();
+                            sendJsonMessageWithType(ctx, offlinePlayers, "getAllPlayers");
+                        }
+                        case "getPlayerInventory" -> {
+                            if (args.length < 3) throw new IllegalArgumentException(Constants.PLAYER_MISSING_PARAMS);
+                            try {
+                                ArrayList<ItemStack> inv = PlayerApi.getPlayerInv(ValidationUtils.safeUUID(args[1]), ValidationUtils.safeUUID(args[2]));
+                                sendJsonMessageWithType(ctx, inv, "getPlayerInventory");
+                            } catch (IOException e) {
+                                throw new IllegalArgumentException(Constants.INTERNAL_SERVER_ERROR);
+                            }
+                        }
+                        default -> throw new IllegalArgumentException(Constants.UNKNOWN_WEBSOCKET_COMMAND);
+                    }
+                } catch (IllegalArgumentException e) {
+                    sendJsonErrorWithType(ctx, e.getMessage(), args[0]);
                 }
             }
         });
     }
 
-    /**
-     * Sends the specified message (as JSON) to all subscribed clients.
-     *
-     * @param message Object can be any Jackson/JSON serializable object
-     */
-    public static void broadcast(Object message) {
-        subscribers.values().stream().filter(ctx -> ctx.session.isOpen()).forEach(session -> {
-            session.send(message);
-        });
+    private static void sendJsonMessageWithType(WsContext cxt, Object json, String type) {
+        cxt.send(gson.toJson(new JsonMessageWithType(json, type)));
+    }
+    private static void sendJsonErrorWithType(WsContext cxt, String error, String type) {
+        cxt.send(gson.toJson(new JsonErrorWithType(error, type)));
     }
 
-    /**
-     * Generate a unique hash for this subscriber using its connection properties
-     *
-     * @param ctx
-     * @return String the hash
-     */
-    private static String clientHash(WsContext ctx) {
-        return String.format("sub-%s-%s", ctx.host(), ctx.getSessionId());
+    public static class JsonMessageWithType {
+        @Expose
+        Object data;
+
+        @Expose
+        String type;
+
+        public JsonMessageWithType(Object data, String type) {
+            this.data = data;
+            this.type = type;
+        }
     }
+    public static class JsonErrorWithType {
+        @Expose
+        String error;
+
+        @Expose
+        String type;
+
+        public JsonErrorWithType(String error, String type) {
+            this.error = error;
+            this.type = type;
+        }
+    }
+
 }


### PR DESCRIPTION
This is essentially a proposal for adding functionality to the websocket portion of the project. It is incomplete but shows how it could be done. 

- Refactors `PlayerAPI.java` to separate data collection from request handling, allowing the data collection to be reused from the websocket portion
- Renames `WebsocketHandler` to `ConsoleWebsocketHandler`
- Creates `WebsocketHandler` to handle the `v1/ws` endpoint, with inputs following mostly the ones in the `v1/player` api. Outputs are JSON strings including either an `error` or `data`, along with `type`, the type of data being sent. 

Here's a Node.js sample client:
```js
import { client } from "websocket";
import { createInterface } from "readline";

const ws = new client();
const rl = createInterface({
    input: process.stdin,
    output: process.stdout,
});

ws.on("connect", (conn) => {
    console.log("Connection established");
    rl.on("line", (line) => conn.send(line));
    conn.on("message", (message) => {
        console.log(JSON.parse(message.utf8Data));
    });
});

ws.on("connectFailed", console.log);

ws.connect("ws://localhost:4567/v1/ws", undefined, undefined, {
    Cookie: "x-servertap-key=change_me",
});
```

Feedback appreciated, and if this format makes sense I will continue with the other apis. 