### PR TITLE
Use native Bukkit/Spigot types when possible

### DIFF
--- a/src/main/java/io/servertap/api/v1/PlayerApi.java
+++ b/src/main/java/io/servertap/api/v1/PlayerApi.java
@@ -104,7 +104,7 @@ public class PlayerApi {
         p.setHealth(player.getHealth());
         p.setSaturation(player.getSaturation());
 
-        p.setDimension(player.getWorld().getEnvironment().toString());
+        p.setDimension(player.getWorld().getEnvironment());
 
         Location playerLocation = player.getLocation();
         Double[] convertedLocation = new Double[3];
@@ -114,7 +114,7 @@ public class PlayerApi {
 
         p.setLocation(convertedLocation);
 
-        p.setGamemode(player.getGameMode().toString());
+        p.setGamemode(player.getGameMode());
 
         p.setLastPlayed(player.getLastPlayed());
 

--- a/src/main/java/io/servertap/api/v1/WorldApi.java
+++ b/src/main/java/io/servertap/api/v1/WorldApi.java
@@ -291,30 +291,12 @@ public class WorldApi {
 
         world.setName(bukkitWorld.getName());
         world.setUuid(bukkitWorld.getUID().toString());
-
-        // TODO: The Enum for Environment makes this annoying to get
         world.setEnvironment(bukkitWorld.getEnvironment());
         world.setTime(BigDecimal.valueOf(bukkitWorld.getTime()));
         world.setAllowAnimals(bukkitWorld.getAllowAnimals());
         world.setAllowMonsters(bukkitWorld.getAllowMonsters());
         world.setGenerateStructures(bukkitWorld.canGenerateStructures());
-
-        int value = 0;
-        switch (bukkitWorld.getDifficulty()) {
-            case PEACEFUL:
-                value = 0;
-                break;
-            case EASY:
-                value = 1;
-                break;
-            case NORMAL:
-                value = 3;
-                break;
-            case HARD:
-                value = 2;
-                break;
-        }
-        world.setDifficulty(value);
+        world.setDifficulty(bukkitWorld.getDifficulty());
         world.setSeed(BigDecimal.valueOf(bukkitWorld.getSeed()));
         world.setStorm(bukkitWorld.hasStorm());
         world.setThundering(bukkitWorld.isThundering());

--- a/src/main/java/io/servertap/api/v1/WorldApi.java
+++ b/src/main/java/io/servertap/api/v1/WorldApi.java
@@ -12,6 +12,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.World.Environment;
 import org.bukkit.plugin.Plugin;
 
 import java.io.BufferedOutputStream;
@@ -35,6 +36,7 @@ public class WorldApi {
     @OpenApi(
             path = "/v1/worlds/save",
             summary = "Triggers a world save of all worlds",
+            operationId = "saveAllWorlds",
             method = HttpMethod.POST,
             tags = {"Server"},
             headers = {
@@ -70,6 +72,7 @@ public class WorldApi {
             path = "/v1/worlds/{uuid}/save",
             summary = "Triggers a world save",
             method = HttpMethod.POST,
+            operationId = "saveWorld",
             tags = {"Server"},
             headers = {
                     @OpenApiParam(name = "key")
@@ -147,6 +150,7 @@ public class WorldApi {
     @OpenApi(
             path = "/v1/worlds/{uuid}/download",
             summary = "Downloads a ZIP compressed archive of the world's folder",
+            operationId = "downloadWorldZip",
             method = HttpMethod.GET,
             tags = {"Server"},
             headers = {
@@ -192,6 +196,7 @@ public class WorldApi {
     @OpenApi(
             path = "/v1/worlds/download",
             summary = "Downloads a ZIP compressed archive of all the worlds' folders",
+            operationId = "downloadAllWorldsZip",
             method = HttpMethod.GET,
             tags = {"Server"},
             headers = {
@@ -235,12 +240,13 @@ public class WorldApi {
     @OpenApi(
             path = "/v1/worlds",
             summary = "Get information about all worlds",
+            operationId = "getWorlds",
             tags = {"Server"},
             headers = {
                     @OpenApiParam(name = "key")
             },
             responses = {
-                    @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class, isArray = true))
+                    @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class, isArray = true, type = "application/json"))
             }
     )
     public static void worldsGet(Context ctx) {
@@ -253,6 +259,7 @@ public class WorldApi {
     @OpenApi(
             path = "/v1/worlds/{uuid}",
             summary = "Get information about a specific world",
+            operationId = "getWorld",
             tags = {"Server"},
             headers = {
                     @OpenApiParam(name = "key")
@@ -261,7 +268,7 @@ public class WorldApi {
                     @OpenApiParam(name = "uuid", description = "The uuid of the world")
             },
             responses = {
-                    @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class))
+                    @OpenApiResponse(status = "200", content = @OpenApiContent(from = World.class, type = "application/json"))
             }
     )
     public static void worldGet(Context ctx) {
@@ -286,21 +293,7 @@ public class WorldApi {
         world.setUuid(bukkitWorld.getUID().toString());
 
         // TODO: The Enum for Environment makes this annoying to get
-        switch (bukkitWorld.getEnvironment()) {
-            case NORMAL:
-                world.setEnvironment(0);
-                break;
-            case NETHER:
-                world.setEnvironment(-1);
-                break;
-            case THE_END:
-                world.setEnvironment(1);
-                break;
-            default:
-                world.setEnvironment(0);
-                break;
-        }
-
+        world.setEnvironment(bukkitWorld.getEnvironment());
         world.setTime(BigDecimal.valueOf(bukkitWorld.getTime()));
         world.setAllowAnimals(bukkitWorld.getAllowAnimals());
         world.setAllowMonsters(bukkitWorld.getAllowMonsters());
@@ -322,7 +315,6 @@ public class WorldApi {
                 break;
         }
         world.setDifficulty(value);
-
         world.setSeed(BigDecimal.valueOf(bukkitWorld.getSeed()));
         world.setStorm(bukkitWorld.hasStorm());
         world.setThundering(bukkitWorld.isThundering());

--- a/src/main/java/io/servertap/api/v1/models/Player.java
+++ b/src/main/java/io/servertap/api/v1/models/Player.java
@@ -1,5 +1,8 @@
 package io.servertap.api.v1.models;
 
+import org.bukkit.GameMode;
+import org.bukkit.World.Environment;
+
 import com.google.gson.annotations.Expose;
 
 /**
@@ -40,7 +43,7 @@ public class Player {
     private Double[] location = null;
 
     @Expose
-    private String dimension = null;
+    private Environment dimension = null;
 
     @Expose
     private Double health = null;
@@ -52,7 +55,7 @@ public class Player {
     private Float saturation = null;
 
     @Expose
-    private String gamemode = null;
+    private GameMode gamemode = null;
 
     @Expose
     private Long lastPlayed = null;
@@ -252,11 +255,11 @@ public class Player {
      *
      * @return world
      */
-    public String getDimension() {
+    public Environment getDimension() {
         return dimension;
     }
 
-    public void setDimension(String dimension) {
+    public void setDimension(Environment dimension) {
         this.dimension = dimension;
     }
 
@@ -304,11 +307,11 @@ public class Player {
      *
      * @return gamemode
      */
-    public String getGamemode() {
+    public GameMode getGamemode() {
         return gamemode;
     }
 
-    public void setGamemode(String gamemode) {
+    public void setGamemode(GameMode gamemode) {
         this.gamemode = gamemode;
     }
 

--- a/src/main/java/io/servertap/api/v1/models/World.java
+++ b/src/main/java/io/servertap/api/v1/models/World.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.Expose;
 
 import java.math.BigDecimal;
 
+import org.bukkit.Difficulty;
 import org.bukkit.World.Environment;
 
 /**
@@ -35,7 +36,7 @@ public class World {
     private Boolean allowMonsters = null;
 
     @Expose
-    private Integer difficulty = null;
+    private Difficulty difficulty = null;
 
     @Expose
     private Environment environment = null;
@@ -177,7 +178,7 @@ public class World {
         this.allowMonsters = allowMonsters;
     }
 
-    public World difficulty(Integer difficulty) {
+    public World difficulty(Difficulty difficulty) {
         this.difficulty = difficulty;
         return this;
     }
@@ -187,11 +188,11 @@ public class World {
      *
      * @return difficulty
      **/
-    public Integer getDifficulty() {
+    public Difficulty getDifficulty() {
         return difficulty;
     }
 
-    public void setDifficulty(Integer difficulty) {
+    public void setDifficulty(Difficulty difficulty) {
         this.difficulty = difficulty;
     }
 

--- a/src/main/java/io/servertap/api/v1/models/World.java
+++ b/src/main/java/io/servertap/api/v1/models/World.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.Expose;
 
 import java.math.BigDecimal;
 
+import org.bukkit.World.Environment;
+
 /**
  * A Minecraft world
  */
@@ -36,7 +38,7 @@ public class World {
     private Integer difficulty = null;
 
     @Expose
-    private Integer environment = null;
+    private Environment environment = null;
 
     @Expose
     private BigDecimal seed = null;
@@ -193,7 +195,7 @@ public class World {
         this.difficulty = difficulty;
     }
 
-    public World environment(Integer environment) {
+    public World environment(Environment environment) {
         this.environment = environment;
         return this;
     }
@@ -203,11 +205,11 @@ public class World {
      *
      * @return environment
      **/
-    public Integer getEnvironment() {
+    public Environment getEnvironment() {
         return environment;
     }
 
-    public void setEnvironment(Integer environment) {
+    public void setEnvironment(Environment environment) {
         this.environment = environment;
     }
 

--- a/src/main/java/io/servertap/api/v1/models/World.java
+++ b/src/main/java/io/servertap/api/v1/models/World.java
@@ -184,7 +184,7 @@ public class World {
     }
 
     /**
-     * Peaceful (0), Easy (1), Normal (2), Hard (3)
+     * Peaceful(PEACEFUL), Easy(EASY), Normal(NORMAL), Hard(HARD)
      *
      * @return difficulty
      **/
@@ -202,7 +202,7 @@ public class World {
     }
 
     /**
-     * Overworld (0), Nether (-1), End (1)
+     * Overworld (NORMAL), Nether (NETHER), End (THE_END), Custom (CUSTOM)
      *
      * @return environment
      **/


### PR DESCRIPTION
Before we were converting types like Difficulty and Dimension to integers before sending them but there is no reason to do so. This PR changes this by sending the original type. 

Effects

Dimensions/Environments
0 => "NORMAL"
1 => "NETHER"
3 => "CUSTOM"

Difficulty
0 => "PEACEFUL"
1 => "EASY"

GAMEMODE
0 => "CREATIVE"

This will in theory make requests take less time and should make the experience of creating programatic requests with something like an SDK easier

However this will be a breaking change 