### PR TITLE
excluded kotlin-stdlib from the shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,11 @@
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
+                        </filter>
+                        <filter>
+                            <artifact>org.jetbrains.kotlin:kotlin-stdlib</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
Attempted fix for #203 