### PR TITLE
Make the compiled jar smaller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.4.1</version>
                 <configuration>
+                    <minimizeJar>true</minimizeJar>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
 
                     <filters>

--- a/src/main/java/io/servertap/api/v1/ServerApi.java
+++ b/src/main/java/io/servertap/api/v1/ServerApi.java
@@ -643,7 +643,11 @@ public class ServerApi {
         }
 
         String timeRaw = ctx.formParam("time");
-        AtomicLong time = new AtomicLong(timeRaw != null ? Long.parseLong(timeRaw) : 0);
+        if (StringUtils.isBlank(timeRaw)) {
+            timeRaw = "0";
+        }
+
+        AtomicLong time = new AtomicLong(Long.parseLong(timeRaw));
         if (time.get() < 0) time.set(0);
 
         ctx.future(() -> runCommandAsync(command, time.get()).thenAccept(


### PR DESCRIPTION
Using minimizeJar results in a 20MB jar where it was a 28MB jar before.

Tested all routes, all looks good.

I also fixed a parsing error if you pass `time=` (i.e. blank) into `/v1/server/exec`