### PR TITLE
Added Config Options to disable Endpoint Categories, Swagger and specific Paths

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,3 +33,27 @@ corsOrigins:
 # Number of console log lines to send when websocket connections are opened
 # Set to 0 to effectively disable this
 websocketConsoleBuffer: 1000
+
+# Enable or disable certain groups of endpoints.
+# See the Swagger UI at http://your-server:4567/swagger
+enabled-endpoint-categories:
+  ping: true
+  server: true
+  worlds: true
+  scoreboard: true
+  chat: true
+  players: true
+  economy: true
+  plugins: true
+  placeholders: true
+  websocket-console: true
+  advancements: true
+
+# If you do not wish to show the swagger UI you can disable it here
+disable-swagger: false
+
+# If you do not want to disable full categories you can blacklist certain paths.
+# Use the full paths including the API Version as shown in Swagger UI!
+blocked-paths:
+# - /v1/ping
+# - /v1/plugins

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -34,26 +34,13 @@ corsOrigins:
 # Set to 0 to effectively disable this
 websocketConsoleBuffer: 1000
 
-# Enable or disable certain groups of endpoints.
-# See the Swagger UI at http://your-server:4567/swagger
-enabled-endpoint-categories:
-  ping: true
-  server: true
-  worlds: true
-  scoreboard: true
-  chat: true
-  players: true
-  economy: true
-  plugins: true
-  placeholders: true
-  websocket-console: true
-  advancements: true
-
 # If you do not wish to show the swagger UI you can disable it here
 disable-swagger: false
 
-# If you do not want to disable full categories you can blacklist certain paths.
-# Use the full paths including the API Version as shown in Swagger UI!
+# Use this feature to configure paths that will be blocked.
+# You can use * as wildcard placeholders to match anything you like.
+# The placeholders from Swagger UI like {uuid} are handled the same way as a *.
 blocked-paths:
 # - /v1/ping
-# - /v1/plugins
+# - /v1/players/{uuid}
+# - /v1/server/*


### PR DESCRIPTION
As ServerTap provides Paths to critical Server Data and Functionality (e.g. `/v1/server/ops`) I wanted the Option to disable some of them.

I added three things:
1. Config Options to disable Categories of Paths. You could for example disable all Paths for Worlds.
2. A Config Option to disable Swagger and Swagger-Docs (could be useful in Production Environments)
3. A Config Option to disable specific Paths. If I would for example like to disable `/v1/server/whitelist` but keep the other Server Endpoints I could add only this one to the Blocked-Paths List. Requests will get a 403 - Forbidden returned if the Paths are blocked.

The default Config is designed so everything stays enabled by default. You have to opt-out of everything.